### PR TITLE
getでデータがない場合にnullが返ってきていたが、空配列を返すように修正

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func DataGet(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	var data []map[string]interface{}
+	data := make([]map[string]interface{}, 0)
 	for _, doc := range docs {
 		data = append(data, doc.Data())
 	}


### PR DESCRIPTION
`get /Data` でデータがない場合にnullが返ってきていたが、空配列を返すように修正